### PR TITLE
Run unit tests for directives with external templates with grunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ UpgradeLog*.htm
 
 .grunt
 _SpecRunner.html
+
+#Angular directive templates converted in javascript. Used in client tests.
+Tests/Telerik.Sitefinity.Frontend.ClientTest/templates.js

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,20 +24,20 @@ module.exports = function (grunt) {
 	  'Tests/Telerik.Sitefinity.Frontend.ClientTest/helpers/angular-resource.js',
       'Tests/Telerik.Sitefinity.Frontend.ClientTest/helpers/angular-route.js',
       'Tests/Telerik.Sitefinity.Frontend.ClientTest/helpers/angular-mocks.js',
+	  'Tests/Telerik.Sitefinity.Frontend.ClientTest/templates.js',
 	  'Telerik.Sitefinity.Frontend/MVC/Scripts/Bootstrap/js/*.js',
-	  'Telerik.Sitefinity.Frontend/Designers/Scripts/*.js',	  
+	  'Telerik.Sitefinity.Frontend/Designers/Scripts/*.js',
 	  'Telerik.Sitefinity.Frontend/MVC/Scripts/Designer/*.js',
 	  'Telerik.Sitefinity.Frontend/MVC/Scripts/*.js',
       'Telerik.Sitefinity.Frontend/Services/services.js',
 	  'Telerik.Sitefinity.Frontend/Services/generic-data-service.js',
 	  'Telerik.Sitefinity.Frontend/Selectors/selectors.js',
-	  'Telerik.Sitefinity.Frontend/Selectors/content-selector.js',	  
+	  'Telerik.Sitefinity.Frontend/Selectors/content-selector.js',
       '!Telerik.Sitefinity.Frontend/Mvc/Scripts/Angular/**',
 	  '!Telerik.Sitefinity.Frontend/Designers/Scripts/page-editor.js',
 	  'Tests/Telerik.Sitefinity.Frontend.ClientTest/helpers/mocks/*.js'],
 				options: {
-					specs: ['Tests/Telerik.Sitefinity.Frontend.ClientTest/unit/**/*.js',
-							'!Tests/Telerik.Sitefinity.Frontend.ClientTest/unit/Selectors/contentSelectorSpec.js'],
+					specs: ['Tests/Telerik.Sitefinity.Frontend.ClientTest/unit/**/*.js'],
 					template: require('grunt-template-jasmine-istanbul'),
 					templateOptions: {
 						coverage: 'Tests/Telerik.Sitefinity.Frontend.ClientTest/coverage/coverage.json',
@@ -49,14 +49,28 @@ module.exports = function (grunt) {
 					}
 				}
 			}
-		}
+		},
+		
+		//Converts directive's external html templates into javascript strings and stores them in the Angular's $templateCache service.
+		html2js: {
+			options: {
+			  singleModule: true,
+			  module: 'templates',
+			  base: 'Telerik.Sitefinity.Frontend'
+			},
+			main: {
+			  src: ['Telerik.Sitefinity.Frontend/Selectors/*.html'],
+			  dest: 'Tests/Telerik.Sitefinity.Frontend.ClientTest/templates.js'
+			},
+		},
 	});
 	
 	//Load the needed plugins
 	grunt.loadNpmTasks('grunt-contrib-jshint');
 	grunt.loadNpmTasks('grunt-contrib-jasmine');
+	grunt.loadNpmTasks('grunt-html2js');
 	
 	//Default task(s)
-	grunt.registerTask('default', ['jshint', 'jasmine']);
+	grunt.registerTask('default', ['jshint','html2js', 'jasmine']);
 	
 };

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "grunt": "^0.4.4",
     "grunt-contrib-jasmine": "^0.3.0",
     "grunt-contrib-jshint": "^0.10.0",
+    "grunt-html2js": "^0.2.8",
     "grunt-template-jasmine-istanbul": "~0.2.4",
     "karma": "~0.12.19",
     "karma-chrome-launcher": "^0.1.4",


### PR DESCRIPTION
To be able to run Jasmine tests for directives that have an external template in a html file, we have to run the grunt task https://github.com/karlgoldstein/grunt-html2js. It saves all templates in a javascript file and registers them in the Angular's $templateCache service. In the client test we get the template from the cache instead of performing get request for a html file.
