### PR TITLE
Fixed typo in property name

### DIFF
--- a/Telerik.Sitefinity.Frontend/Selectors/taxon-selector.js
+++ b/Telerik.Sitefinity.Frontend/Selectors/taxon-selector.js
@@ -30,7 +30,7 @@
                                 ctrl.updateSelectedItem(data);
                             }
 
-                            if (!ctrl.getSelelectedItemId()) {
+                            if (!ctrl.getSelectedItemId()) {
                                 ctrl.updateSelectedItemId(data.Id);
                             }
                         };


### PR DESCRIPTION
Bugfix: TP275342 News widget: When select one news item and edit news widget, the following error occurs in browser console: undefined is not a function
