### PR TITLE
#89 Add error message when Exception occurs during the execution of a controller's action

### DIFF
--- a/Telerik.Sitefinity.Frontend/Mvc/Infrastructure/InfrastructureResources.cs
+++ b/Telerik.Sitefinity.Frontend/Mvc/Infrastructure/InfrastructureResources.cs
@@ -1,0 +1,56 @@
+﻿using Telerik.Sitefinity.Localization;
+
+namespace Telerik.Sitefinity.Frontend.Mvc.Infrastructure
+{
+    /// <summary>
+    /// Localizable strings for the Frontend infrastructure.
+    /// </summary>
+    [ObjectInfo(typeof(InfrastructureResources), Title = "InfrastructureResourcesTitle", Description = "InfrastructureResourcesDescription")]
+    public class InfrastructureResources : Resource
+    {
+        /// <summary>
+        /// Title for the infrastructure resources class.
+        /// </summary>
+        [ResourceEntry("InfrastructureResourcesTitle",
+            Value = "Frontend Infrastructure resources",
+            Description = "Title for the infrastructure resources class.",
+            LastModified = "2015/01/12")]
+        public string InfrastructureResourcesTitle
+        {
+            get
+            {
+                return this["InfrastructureResourcesTitle"];
+            }
+        }
+
+        /// <summary>
+        /// Description for the infrastructure resources class.
+        /// </summary>
+        [ResourceEntry("InfrastructureResourcesDescription",
+            Value = "Localizable strings for the Frontend infrastructure.",
+            Description = "Description for the infrastructure resources class.",
+            LastModified = "2015/01/12")]
+        public string InfrastructureResourcesDescription
+        {
+            get
+            {
+                return this["InfrastructureResourcesDescription"];
+            }
+        }
+
+        /// <summary>
+        /// Message that is to be displayed for a widget when its controller execution throws exception.
+        /// </summary>
+        [ResourceEntry("ErrorExecutingController",
+            Value = "Exception occured while executing the controller. Check error logs for details.",
+            Description = "Description for the infrastructure resources class.",
+            LastModified = "2015/01/12")]
+        public string ErrorExecutingController
+        {
+            get
+            {
+                return this["ErrorExecutingController"];
+            }
+        }
+    }
+}

--- a/Telerik.Sitefinity.Frontend/Mvc/Infrastructure/Routing/DynamicUrlParamActionInvoker.cs
+++ b/Telerik.Sitefinity.Frontend/Mvc/Infrastructure/Routing/DynamicUrlParamActionInvoker.cs
@@ -2,12 +2,15 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using System.Web;
+using System.Web.Configuration;
 using System.Web.Mvc;
 using Telerik.Sitefinity.Abstractions;
 using Telerik.Sitefinity.Configuration;
 using Telerik.Sitefinity.Data;
 using Telerik.Sitefinity.DynamicModules.Model;
 using Telerik.Sitefinity.Frontend.Mvc.Infrastructure.Controllers;
+using Telerik.Sitefinity.Localization;
 using Telerik.Sitefinity.Model;
 using Telerik.Sitefinity.Modules.Pages.Configuration;
 using Telerik.Sitefinity.Mvc;
@@ -76,6 +79,9 @@ namespace Telerik.Sitefinity.Frontend.Mvc.Infrastructure.Routing
                     throw;
 
                 proxyControl.Context.Response.Clear();
+
+                if (this.ShouldDisplayErrors())
+                    proxyControl.Context.Response.Write(Res.Get<InfrastructureResources>().ErrorExecutingController);
             }
         }
 
@@ -97,6 +103,21 @@ namespace Telerik.Sitefinity.Frontend.Mvc.Infrastructure.Routing
                 result.SetLast(new DefaultUrlParamsMapper(controller));
 
             return result;
+        }
+
+        /// <summary>
+        /// Determines whether errors should be displayed.
+        /// </summary>
+        /// <returns>True if errors should be displayed, False to fail silently.</returns>
+        protected virtual bool ShouldDisplayErrors()
+        {
+            var configuration = WebConfigurationManager.OpenWebConfiguration("~/Web.config");
+            var customErrors = configuration.GetSection("system.web/customErrors") as CustomErrorsSection;
+
+            if (customErrors == null)
+                return true;
+
+            return customErrors.Mode == CustomErrorsMode.Off || (customErrors.Mode == CustomErrorsMode.RemoteOnly && HttpContext.Current.Request.IsLocal);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes")]

--- a/Telerik.Sitefinity.Frontend/Resources/ResourcesInitiliazer.cs
+++ b/Telerik.Sitefinity.Frontend/Resources/ResourcesInitiliazer.cs
@@ -3,15 +3,13 @@ using System.Web.Mvc;
 using System.Web.Routing;
 using Telerik.Microsoft.Practices.Unity;
 using Telerik.Sitefinity.Abstractions;
-using Telerik.Sitefinity.Data;
 using Telerik.Sitefinity.Data.Events;
 using Telerik.Sitefinity.Frontend.Modules.ControlTemplates.Web.UI;
 using Telerik.Sitefinity.Frontend.Mvc.Infrastructure;
 using Telerik.Sitefinity.Frontend.Resources.Resolvers;
+using Telerik.Sitefinity.Localization;
 using Telerik.Sitefinity.Modules.ControlTemplates.Web.UI;
-using Telerik.Sitefinity.Modules.Libraries.Web.Events;
 using Telerik.Sitefinity.Modules.Pages;
-using Telerik.Sitefinity.Mvc.Store;
 using Telerik.Sitefinity.Pages.Model;
 using Telerik.Sitefinity.Services;
 using Telerik.Sitefinity.Utilities.TypeConverters;
@@ -39,6 +37,13 @@ namespace Telerik.Sitefinity.Frontend.Resources
             ObjectFactory.Container.RegisterType<DialogBase, MvcControlTemplateEditor>(typeof(ControlTemplateEditor).Name);
 
             EventHub.Subscribe<IDataEvent>(x => this.HandleIDataEvent(x));
+
+            var resourceClass = typeof(InfrastructureResources);
+            var resourceClassId = Res.GetResourceClassId(resourceClass);
+            if (!ObjectFactory.Container.IsRegistered(resourceClass, resourceClassId))
+            {
+                Res.RegisterResource(resourceClass);
+            }
         }
 
         /// <summary>

--- a/Telerik.Sitefinity.Frontend/Telerik.Sitefinity.Frontend.csproj
+++ b/Telerik.Sitefinity.Frontend/Telerik.Sitefinity.Frontend.csproj
@@ -219,6 +219,7 @@
     <Compile Include="Mvc\Infrastructure\Controllers\IRouteMapper.cs" />
     <Compile Include="Mvc\Infrastructure\Controllers\MvcWidgetProxy.cs" />
     <Compile Include="Mvc\Infrastructure\Controllers\VoidViewLocationCache.cs" />
+    <Compile Include="Mvc\Infrastructure\InfrastructureResources.cs" />
     <Compile Include="Mvc\Infrastructure\Layouts\LayoutMvcPageResolver.cs" />
     <Compile Include="Mvc\Infrastructure\Layouts\PageTemplateExtensions.cs" />
     <Compile Include="Mvc\Infrastructure\Layouts\LayoutInitializer.cs" />
@@ -525,7 +526,7 @@
   <Import Project="$(SolutionDir)\StyleCop\StyleCop.targets" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties OpenAccess_EnhancementOutputLevel="1" OpenAccess_UpdateDatabase="False" OpenAccess_Enhancing="False" OpenAccess_ConnectionId="DatabaseConnection1" OpenAccess_ConfigFile="App.config" />
+      <UserProperties OpenAccess_ConfigFile="App.config" OpenAccess_ConnectionId="DatabaseConnection1" OpenAccess_Enhancing="False" OpenAccess_UpdateDatabase="False" OpenAccess_EnhancementOutputLevel="1" />
     </VisualStudio>
   </ProjectExtensions>
   <PropertyGroup>

--- a/Tests/Telerik.Sitefinity.Frontend.TestIntegration/Mvc/Infrastructure/DynamicUrlActionInvokerTests.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestIntegration/Mvc/Infrastructure/DynamicUrlActionInvokerTests.cs
@@ -1,0 +1,49 @@
+﻿using MbUnit.Framework;
+using Telerik.Sitefinity.Frontend.Mvc.Infrastructure;
+using Telerik.Sitefinity.Frontend.TestUtilities.Mvc.Controllers;
+using Telerik.Sitefinity.Localization;
+using Telerik.Sitefinity.Mvc.Proxy;
+using Telerik.Sitefinity.TestIntegration.Data.Content;
+using Telerik.Sitefinity.TestIntegration.Helpers;
+using Telerik.Sitefinity.Web;
+
+namespace Telerik.Sitefinity.Frontend.TestIntegration.Mvc.Infrastructure
+{
+    /// <summary>
+    /// This class contains tests for controller action invoking.
+    /// </summary>
+    [TestFixture]
+    [Category(TestCategories.MvcCore)]
+    [Description("This class contains tests for controller action invoking.")]
+    public class DynamicUrlActionInvokerTests
+    {
+        /// <summary>
+        /// Checks whether error message is rendered when a controller throws exception.
+        /// </summary>
+        [Test]
+        [Author("Boyko-Karadzhov")]
+        [Description("Checks whether error message is rendered when a controller throws exception.")]
+        public void CreatePageWithFailingWidget_RenderPage_ResponseContainsErrorMessage()
+        {
+            string testName = System.Reflection.MethodInfo.GetCurrentMethod().Name;
+            string pageNamePrefix = testName + "MvcPage";
+            string pageTitlePrefix = testName + "Mvc Page";
+            string urlNamePrefix = testName + "mvc-page";
+            int index = 1;
+            string url = UrlPath.ResolveAbsoluteUrl("~/" + urlNamePrefix + index);
+
+            var mvcProxy = new MvcControllerProxy();
+            mvcProxy.ControllerName = typeof(DummyFailingController).FullName;
+
+            using (var contentGenerator = new PageContentGenerator())
+            {
+                contentGenerator.CreatePageWithWidget(mvcProxy, string.Empty, pageNamePrefix, pageTitlePrefix, urlNamePrefix, index);
+
+                string responseContent = WebRequestHelper.GetPageWebContent(url);
+                string expectedResult = Res.Get<InfrastructureResources>().ErrorExecutingController;
+
+                Assert.Contains(responseContent, expectedResult, "The expected error message was not found on the page!");
+            }
+        }
+    }
+}

--- a/Tests/Telerik.Sitefinity.Frontend.TestIntegration/Telerik.Sitefinity.Frontend.TestIntegration.csproj
+++ b/Tests/Telerik.Sitefinity.Frontend.TestIntegration/Telerik.Sitefinity.Frontend.TestIntegration.csproj
@@ -140,6 +140,7 @@
     <Compile Include="GridWidgets\GridWidgetsTests.cs" />
     <Compile Include="LayoutTemplates\LayoutTemplatesTests.cs" />
     <Compile Include="Mvc\Helpers\ResourceHelperTests.cs" />
+    <Compile Include="Mvc\Infrastructure\DynamicUrlActionInvokerTests.cs" />
     <Compile Include="Mvc\Models\ContentModelBaseTests.cs" />
     <Compile Include="Mvc\Routing\RoutingTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Tests/Telerik.Sitefinity.Frontend.TestUtilities/DummyClasses/Mvc/Controllers/DummyFailingController.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUtilities/DummyClasses/Mvc/Controllers/DummyFailingController.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Web.Mvc;
+
+namespace Telerik.Sitefinity.Frontend.TestUtilities.Mvc.Controllers
+{
+    /// <summary>
+    /// This class represents a controller that has one action and it always throws exception. Used for testing purposes.
+    /// </summary>
+    public class DummyFailingController : Controller
+    {
+        /// <summary>
+        /// The default action of the controller.
+        /// </summary>
+        /// <returns>Returns nothing. Always throws exception.</returns>
+        /// <exception cref="System.Exception">Always fails.</exception>
+        [SuppressMessage("Microsoft.Usage", "CA2201:DoNotRaiseReservedExceptionTypes")]
+        public ViewResult Index()
+        {
+            throw new Exception("Always fails.");
+        }
+    }
+}

--- a/Tests/Telerik.Sitefinity.Frontend.TestUtilities/Telerik.Sitefinity.Frontend.TestUtilities.csproj
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUtilities/Telerik.Sitefinity.Frontend.TestUtilities.csproj
@@ -195,6 +195,7 @@
     <Compile Include="DummyClasses\Mvc\Controllers\DummyControllerFactory.cs" />
     <Compile Include="DummyClasses\LocalizationResources\DummyControllerResoruces.cs" />
     <Compile Include="DummyClasses\Mvc\Controllers\DummyCustomDesignerController.cs" />
+    <Compile Include="DummyClasses\Mvc\Controllers\DummyFailingController.cs" />
     <Compile Include="DummyClasses\Mvc\Controllers\DummyOldDesignerController.cs" />
     <Compile Include="DummyClasses\Mvc\Controllers\DummyScriptController.cs" />
     <Compile Include="DummyClasses\Mvc\Controllers\DummyMasterDetailController.cs" />


### PR DESCRIPTION
Modify the ExecuteController method of the DynamicUrlParamActionInvoker class in order to provide a brief message that error has been occurred.