### PR TITLE
Link service tests

### DIFF
--- a/Telerik.Sitefinity.Frontend/client-components/selectors/tools/sf-link-service.js
+++ b/Telerik.Sitefinity.Frontend/client-components/selectors/tools/sf-link-service.js
@@ -13,6 +13,8 @@
         }])
         .factory('sfLinkService', ['serverContext', 'sfLinkMode', function (serverContext, linkMode) {
 
+            var emptyGuid = '00000000-0000-0000-0000-000000000000';
+
             var linkItem = function (linkHtml) {
                 this.mode = linkMode.WebAddress;
                 this.openInNewWindow = false;
@@ -114,7 +116,7 @@
                         //	this.get_pageSelector().get_languageSelectorSelectedCulture() : null;
                         if (selectedPageId) {
                             var key;
-                            if (linkItem.rootNodeId && linkItem.rootNodeId != Telerik.Sitefinity.getEmptyGuid()) {
+                            if (linkItem.rootNodeId && linkItem.rootNodeId != emptyGuid) {
                                 key = linkItem.rootNodeId;
                             }
                             else if (selectedPage) {

--- a/Telerik.Sitefinity.Frontend/client-components/selectors/tools/sf-link-service.js
+++ b/Telerik.Sitefinity.Frontend/client-components/selectors/tools/sf-link-service.js
@@ -26,11 +26,18 @@
                 this.emailAddress = null;
                 this.displayText = '';
 
+                function startsWith (str, subStr) {
+                    return str.slice(0, subStr.length) === subStr;
+                }
+
                 this.setMode = function () {
-                    if (linkHtml.attr('sfref') && linkHtml.attr('sfref').startsWith('[')) {
+                    var sfref = linkHtml.attr('sfref');
+                    var href = linkHtml.attr('href');
+
+                    if (sfref && startsWith(sfref, '[')) {
                         this.mode = linkMode.InternalPage;
                     }
-                    else if (linkHtml.attr('href') && linkHtml.attr('href').indexOf('mailto:') > -1) {
+                    else if (href && href.indexOf('mailto:') > -1) {
                         this.mode = linkMode.EmailAddress;
                     }
                     else {

--- a/Tests/Telerik.Sitefinity.Frontend.ClientTest/config/karma.conf.js
+++ b/Tests/Telerik.Sitefinity.Frontend.ClientTest/config/karma.conf.js
@@ -38,6 +38,7 @@ module.exports = function (config) {
                   '../../Telerik.Sitefinity.Frontend/client-components/selectors/pages/sf-page-selector.js',
                   '../../Telerik.Sitefinity.Frontend/client-components/selectors/pages/sf-page-selector.html',
                   '../../Telerik.Sitefinity.Frontend/client-components/selectors/search/sf-search-service.js',
+                  '../../Telerik.Sitefinity.Frontend/client-components/selectors/tools/sf-link-service.js',
                   'helpers/mocks/*.js',
                   'unit/**'
         ],

--- a/Tests/Telerik.Sitefinity.Frontend.ClientTest/helpers/common-methods.js
+++ b/Tests/Telerik.Sitefinity.Frontend.ClientTest/helpers/common-methods.js
@@ -1,8 +1,24 @@
+/**
+ * Global methods
+ */
+
+if (!String.prototype.format) {
+    String.prototype.format = function () {
+        var newStr = this;
+
+        for (var i = 0; i < arguments.length; i++) {
+            var pattern = new RegExp("\\{"+ i +"\\}", "g");
+            newStr = newStr.replace(pattern, arguments[i]);
+        }
+
+        return newStr;
+    }
+};
+
 var commonMethods = (function () {
     /**
      * Private methods and variables.
      */
-    
 
     /**
      * Return public interface.

--- a/Tests/Telerik.Sitefinity.Frontend.ClientTest/helpers/common-methods.js
+++ b/Tests/Telerik.Sitefinity.Frontend.ClientTest/helpers/common-methods.js
@@ -3,6 +3,12 @@
  */
 
 if (!String.prototype.format) {
+    /**
+     * A format method, attached to the String.prototype.
+     * Allows string formating with given params.
+     * When called on a string, all occurrences of '{n}' n=0,1,2... will be replaced with the params.
+     * @return {String} the formatted string
+     */
     String.prototype.format = function () {
         var newStr = this;
 
@@ -24,6 +30,15 @@ var commonMethods = (function () {
      * Return public interface.
      */
     return {
+        /**
+         * Compiles the given template with the goven scope
+         * and inserts the produced html in the given container marked with a css class.
+         * @param  {String} template  the raw Angular template
+         * @param  {Object} scope     the scope that will be applied to the template
+         * @param  {String} container jQuery selector that will contain the produced html
+         * @param  {String} cssClass  class that will mark the container
+         * @return {undefined}
+         */
         compileDirective: function (template, scope, container, cssClass) {
             var container = container || 'body';
             var cssClass = cssClass || 'testDiv';

--- a/Tests/Telerik.Sitefinity.Frontend.ClientTest/unit/Services/dataServiceSpec.js
+++ b/Tests/Telerik.Sitefinity.Frontend.ClientTest/unit/Services/dataServiceSpec.js
@@ -1,18 +1,5 @@
 ﻿/* Tests for sf-data-service.js */
 describe('sfDataService', function () {
-    if (!String.prototype.format) {
-        String.prototype.format = function () {
-            var newStr = this;
-
-            for (var i = 0; i < arguments.length; i++) {
-                var pattern = new RegExp("\\{"+ i +"\\}", "g");
-                newStr = newStr.replace(pattern, arguments[i]);
-            }
-
-            return newStr;
-        }
-    };    
-
     beforeEach(module('sfServices'));
 
     var appPath = 'http://mysite.com:9999/myapp';

--- a/Tests/Telerik.Sitefinity.Frontend.ClientTest/unit/Services/sfLinkServiceSpec.js
+++ b/Tests/Telerik.Sitefinity.Frontend.ClientTest/unit/Services/sfLinkServiceSpec.js
@@ -9,7 +9,13 @@ describe('links service', function () {
         linkMode = _sfLinkMode_;
     }));
 
-    describe('generating html link from object', function () {
+    describe('generate html anchor tag from object', function () {
+        it('[GeorgiMateev] / it should return empty link if no item is present.',
+        function () {
+            var link = linksService.getHtmlLink()[0].outerHTML;
+            expect(link).toBe('<a></a>');
+        });
+
         it('[GeorgiMateev] / it should return link from a web address.',
         function () {
             var linkItem = {
@@ -65,12 +71,10 @@ describe('links service', function () {
 
             var link = linksService.getHtmlLink(linkItem, selectedPage)[0].outerHTML;
 
-            var expected = '<a href="http://somesite.com/home" sfref="[{0}|lng:en]{1}">My link</a>'
-                .format(selectedPage.RootId, selectedPage.Id);
+            var expected = '<a href="{0}" sfref="[{1}|lng:en]{2}">My link</a>'
+                .format(selectedPage.FullUrl, selectedPage.RootId, selectedPage.Id);
 
             expect(link).toBe(expected);
-
-            expect(link)
         });
 
         it('[GeorgiMateev] / it should return link from a selected page and given root node Id.',
@@ -88,12 +92,64 @@ describe('links service', function () {
 
             var link = linksService.getHtmlLink(linkItem, selectedPage)[0].outerHTML;
 
-            var expected = '<a href="http://somesite.com/home" sfref="[{0}|lng:en]{1}">My link</a>'
-                .format(linkItem.rootNodeId, selectedPage.Id);
+            var expected = '<a href="{0}" sfref="[{1}|lng:en]{2}">My link</a>'
+                .format(selectedPage.FullUrl, linkItem.rootNodeId, selectedPage.Id);
 
             expect(link).toBe(expected);
+        });
+    });
 
-            expect(link)
+    describe('retrieve data object from jQuery anchor element',  function () {
+        it('[GeorgiMateev] / should get the display text.', function () {
+            var element = $('<a href="mailto:someone@gmail.com">My link</a>');
+
+            var linkItem = linksService.constructLinkItem(element);
+
+            expect(linkItem.displayText).toBe('My link');
+        });
+
+        it('[GeorgiMateev] / should know if the link will be open in a new window.', function () {
+            var element = $('<a target="_blank">My link</a>');
+
+            var linkItem = linksService.constructLinkItem(element);
+
+            expect(linkItem.openInNewWindow).toBe(true);
+        });
+
+        it('[GeorgiMateev] / should get the web address.', function () {
+            var element = $('<a href="http://somesite.com">My link</a>');
+
+            var linkItem = linksService.constructLinkItem(element);
+
+            expect(linkItem.mode).toBe(linkMode.WebAddress);
+            expect(linkItem.webAddress).toBe('http://somesite.com');
+        });
+
+        it('[GeorgiMateev] / should get the mail address.', function () {
+            var element = $('<a href="mailto:someone@gmail.com">My link</a>');
+
+            var linkItem = linksService.constructLinkItem(element);
+
+            expect(linkItem.mode).toBe(linkMode.EmailAddress);
+            expect(linkItem.emailAddress).toBe('someone@gmail.com');
+        });
+
+        it('[GeorgiMateev] / should get page data from the anchor sfref attribute.', function () {
+            var selectedPage = {
+                FullUrl: 'http://somesite.com/home',
+                Id: '4c003fb0-2a77-61ec-be54-ff00007864f',
+                RootId: '4c003fb0-2a77-61ec-bbbb-ff00007864f'
+            };
+
+            var html = '<a sfref="[{0}|lng:en]{1}">My link</a>'
+                .format(selectedPage.RootId, selectedPage.Id);
+
+            var linkItem = linksService.constructLinkItem($(html));
+
+            expect(linkItem.mode).toBe(linkMode.InternalPage);
+            expect(linkItem.pageId).toBe(selectedPage.Id);
+            expect(linkItem.rootNodeId).toBe(selectedPage.RootId);
+            expect(linkItem.language).toBe('en');
         });
     });
 });

--- a/Tests/Telerik.Sitefinity.Frontend.ClientTest/unit/Services/sfLinkServiceSpec.js
+++ b/Tests/Telerik.Sitefinity.Frontend.ClientTest/unit/Services/sfLinkServiceSpec.js
@@ -1,0 +1,99 @@
+describe('links service', function () {
+    beforeEach(module('sfSelectors'));
+
+    var linksService;
+    var linkMode;
+
+    beforeEach(inject(function (_sfLinkService_, _sfLinkMode_) {
+        linksService = _sfLinkService_;
+        linkMode = _sfLinkMode_;
+    }));
+
+    describe('generating html link from object', function () {
+        it('[GeorgiMateev] / it should return link from a web address.',
+        function () {
+            var linkItem = {
+                mode:linkMode.WebAddress,
+                webAddress: 'http://somesite.com',
+                displayText: 'My link'
+            };
+
+            var link = linksService.getHtmlLink(linkItem)[0].outerHTML;
+            var expected = '<a href="http://somesite.com">My link</a>';
+            expect(link).toBe(expected);
+        });
+
+        it('[GeorgiMateev] / it should return link with target new page.',
+        function () {
+            var linkItem = {
+                mode:linkMode.WebAddress,
+                webAddress: 'http://somesite.com',
+                displayText: 'My link',
+                openInNewWindow: true
+            };
+
+            var link = linksService.getHtmlLink(linkItem)[0].outerHTML;
+            var expected = '<a target="_blank" href="http://somesite.com">My link</a>';
+            expect(link).toBe(expected);
+        });
+
+        it('[GeorgiMateev] / it should return link from a mail address.',
+        function () {
+            var linkItem = {
+                mode:linkMode.EmailAddress,
+                emailAddress: 'someone@gmail.com',
+                displayText: 'My link'
+            };
+
+            var link = linksService.getHtmlLink(linkItem)[0].outerHTML;
+            var expected = '<a href="mailto:someone@gmail.com">My link</a>';
+            expect(link).toBe(expected);
+        });
+
+        it('[GeorgiMateev] / it should return link from a selected page.',
+        function () {
+            var selectedPage = {
+                FullUrl: 'http://somesite.com/home',
+                Id: '4c003fb0-2a77-61ec-be54-ff00007864f',
+                RootId: '4c003fb0-2a77-61ec-bbbb-ff00007864f'
+            };
+
+            var linkItem = {
+                mode:linkMode.InternalPage,
+                displayText: 'My link'
+            };
+
+            var link = linksService.getHtmlLink(linkItem, selectedPage)[0].outerHTML;
+
+            var expected = '<a href="http://somesite.com/home" sfref="[{0}|lng:en]{1}">My link</a>'
+                .format(selectedPage.RootId, selectedPage.Id);
+
+            expect(link).toBe(expected);
+
+            expect(link)
+        });
+
+        it('[GeorgiMateev] / it should return link from a selected page and given root node Id.',
+        function () {
+            var selectedPage = {
+                FullUrl: 'http://somesite.com/home',
+                Id: '4c003fb0-2a77-61ec-be54-ff00007864f'
+            };
+
+            var linkItem = {
+                mode:linkMode.InternalPage,
+                displayText: 'My link',
+                rootNodeId: '4c003fb0-2a77-61ec-bbbb-ff00007864f'
+            };
+
+            var link = linksService.getHtmlLink(linkItem, selectedPage)[0].outerHTML;
+
+            var expected = '<a href="http://somesite.com/home" sfref="[{0}|lng:en]{1}">My link</a>'
+                .format(linkItem.rootNodeId, selectedPage.Id);
+
+            expect(link).toBe(expected);
+
+            expect(link)
+        });
+    });
+});


### PR DESCRIPTION
Closes #143 
Contains tests for sf-link-service.js
The following two tests are failing because of bugs in the service:
* should get the display text from given anchor tag
* should get page data from the anchor's sfref attribute

The tests should pass when the bugs are fixed.

- [x] @PepiIvanova 
- [x] @manev 