### PR TITLE
Prevented loading the default MVC designer in case MVC widget has custom WebForms based designer.

### DIFF
--- a/Telerik.Sitefinity.Frontend/Designers/DesignerResolver.cs
+++ b/Telerik.Sitefinity.Frontend/Designers/DesignerResolver.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Telerik.Sitefinity.Abstractions;
 using Telerik.Sitefinity.Frontend.Mvc.Infrastructure.Controllers;
 using Telerik.Sitefinity.Frontend.Resources;
+using Telerik.Sitefinity.Web.UI.ControlDesign;
 
 namespace Telerik.Sitefinity.Frontend.Designers
 {
@@ -27,6 +28,9 @@ namespace Telerik.Sitefinity.Frontend.Designers
             if (widgetType == null)
                 throw new ArgumentNullException("widgetType");
 
+            if (this.HasCustomWebFormsDesigner(widgetType))
+                return null;
+
             string designerUrl;
             if (!this.TryResolveUrlFromAttribute(widgetType, out designerUrl))
                 designerUrl = this.GetDefaultUrl(widgetType);
@@ -34,10 +38,21 @@ namespace Telerik.Sitefinity.Frontend.Designers
             return new PackageManager().EnhanceUrl(designerUrl);
         }
 
-        #endregion 
+        #endregion
 
         #region Private members
-        
+
+        private bool HasCustomWebFormsDesigner(Type widgetType)
+        {
+            var attributes = widgetType.GetCustomAttributes(typeof(ControlDesignerAttribute), inherit: true);
+            var designerAttr = attributes.FirstOrDefault() as ControlDesignerAttribute;
+
+            if (designerAttr != null)
+                return true;
+
+            return false;
+        }
+
         /// <summary>
         /// Resolve a designer URL for the specified widget type if such is specified with <see cref="DesignerUrlAttribute"/>.
         /// </summary>
@@ -86,6 +101,6 @@ namespace Telerik.Sitefinity.Frontend.Designers
 
         private const string DefaultActionUrlTemplate = "~/Telerik.Sitefinity.Frontend/Designer/Master/{0}";
 
-        #endregion 
+        #endregion
     }
 }


### PR DESCRIPTION
For review:
- [x] @dzhenko 
- [x] @ElenaGaneva 