### PR TITLE
Fixed - Image Selector: Selecting a library from breadcrumb is causing emp...

### DIFF
--- a/Telerik.Sitefinity.Frontend/client-components/selectors/media/sf-image-selector.js
+++ b/Telerik.Sitefinity.Frontend/client-components/selectors/media/sf-image-selector.js
@@ -150,7 +150,7 @@
                         if (parent && parent === scope.filterObject.parent) {
                             return;
                         }
-                        scope.sortExpression = null;
+                        
                         scope.filterObject.parent = parent;
                         if (!scope.filterObject.parent) {
                             scope.filterObject.set.basic.allLibraries();


### PR DESCRIPTION
Image Selector: Selecting a library from breadcrumb is causing empty sorting default option closes #478
- [x] @PepiIvanova 
- [x] @ElenaGaneva 