### PR TITLE
Prevent Personalization script from loading if the module is disabled

### DIFF
--- a/Telerik.Sitefinity.Frontend/Mvc/Infrastructure/Layouts/MasterPageBuilder.cs
+++ b/Telerik.Sitefinity.Frontend/Mvc/Infrastructure/Layouts/MasterPageBuilder.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Web;
 using Telerik.Sitefinity.Clients.JS;
+using Telerik.Sitefinity.Configuration;
 using Telerik.Sitefinity.Modules.Pages;
 using Telerik.Sitefinity.Mvc.Rendering;
 using Telerik.Sitefinity.Pages.Model;
@@ -280,11 +281,14 @@ namespace Telerik.Sitefinity.Frontend.Mvc.Infrastructure.Layouts
                 appPath = string.Concat(appPath, "/");
 
             sb.Append(string.Concat("\t<script type=\"text/javascript\">var sf_appPath='", appPath, "';</script>"));
-
-            // add the scripts for personalization in the page
-            sb.Append("\t<script src=\"");
-            sb.Append(pageProxy.ClientScript.GetWebResourceUrl(typeof(PageStatisticsJSClient), "Telerik.Sitefinity.Clients.JS.StatsClient.min.js"));
-            sb.Append("\" type=\"text/javascript\"></script>");
+            
+            if (!SystemManager.IsDesignMode && Config.Get<SystemConfig>().ApplicationModules["Personalization"].StartupType != StartupType.Disabled)
+            {
+                // add the scripts for personalization in the page
+                sb.Append("\t<script src=\"");
+                sb.Append(pageProxy.ClientScript.GetWebResourceUrl(typeof(PageStatisticsJSClient), "Telerik.Sitefinity.Clients.JS.StatsClient.min.js"));
+                sb.Append("\" type=\"text/javascript\"></script>");
+            }
 
             return sb.ToString();
         }


### PR DESCRIPTION
This was fixed in the sitefinity core, but not touched in feather...not sure if there's a better way to check if the module is disabled or not, SystemManager has a ton of internal methods I can't use :)  