### PR TITLE
fixed module initialization and load behavior

### DIFF
--- a/Telerik.Sitefinity.Frontend/FrontendModule.cs
+++ b/Telerik.Sitefinity.Frontend/FrontendModule.cs
@@ -73,24 +73,32 @@ namespace Telerik.Sitefinity.Frontend
         }
 
         /// <summary>
-        /// Initializes the service with specified settings.
+        /// Initializes the module with specified settings.
         /// </summary>
         /// <param name="settings">The settings.</param>
         public override void Initialize(ModuleSettings settings)
         {
             base.Initialize(settings);
 
-            Bootstrapper.Initialized -= this.Bootstrapper_Initialized;
-            Bootstrapper.Initialized += this.Bootstrapper_Initialized;
+            App.WorkWith()
+                .Module(settings.Name)
+                    .Initialize()
+                    .Configuration<FeatherConfig>();
+        }
+
+        /// <summary>
+        /// Integrate the module into the system.
+        /// </summary>
+        public override void Load()
+        {
+            base.Load();
 
             this.ninjectDependencyResolver = this.CreateKernel();
 
             FrontendModuleInstaller.Initialize(this.DependencyResolver);
 
-            App.WorkWith()
-                .Module(settings.Name)
-                    .Initialize()
-                    .Configuration<FeatherConfig>();
+            Bootstrapper.Initialized -= this.Bootstrapper_Initialized;
+            Bootstrapper.Initialized += this.Bootstrapper_Initialized;
         }
 
         /// <summary>


### PR DESCRIPTION
Currently module Initialize() executes a logic that calls ModuleBuilderManager prior to all modules initialization and registration of their manager. This breaks the meta database mapping aggregation and cause slow performance on startup. Moving this logic from Initialize() to Load() method fixes this problem and doesn't change the behavior. It also makes the solution more stable and reliable, as the Load() is the place where the module should be integrated with the system and other modules.

- [x] @Boyko-Karadzhov 
- [x] @Gebov 