### PR TITLE
Migrate UI tests to MSML

### DIFF
--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Framework/TestArrangementBase.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Framework/TestArrangementBase.cs
@@ -1,0 +1,41 @@
+﻿using Telerik.Sitefinity.TestArrangementService.Attributes;
+using Telerik.Sitefinity.TestUI.Arrangements.Framework;
+using Telerik.Sitefinity.TestUtilities.CommonOperations;
+
+namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
+{
+        /// <summary>
+        /// Base class for Test Arrangements classes.
+        /// Default values for the Culture and Site are specified in the testArrangements.config
+        /// </summary>
+        [Culture]
+        [Site]
+        public abstract class TestArrangementBase : ITestArrangement
+        {
+            /// <summary>
+            /// Gets the provider.
+            /// </summary>
+            /// <value>Provider name.</value>
+            protected virtual string DynamicProviderName
+            {
+                get
+                {
+                    if (string.IsNullOrEmpty(this.providerName))
+                    {
+                        this.providerName = ServerOperations.MultiSite().CheckIsMultisiteMode() ?
+                            TestArrangementBase.MultisiteProviderName :
+                            TestArrangementBase.SingleSiteProviderName;
+                    }
+
+                    return this.providerName;
+                }
+            }
+
+            protected readonly string AdminEmail = "admin@test.test";
+            protected readonly string AdminPass = "admin@2";
+            protected readonly string AdninistratorEmail = "administrator@test.test";
+            private const string SingleSiteProviderName = "OpenAccessProvider";
+            private const string MultisiteProviderName = "dynamicContentProvider";
+            private string providerName;
+        }   
+}

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Framework/Utilities/Utilities.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Framework/Utilities/Utilities.cs
@@ -1,0 +1,55 @@
+﻿using Telerik.Sitefinity.TestArrangementService.Attributes;
+using Telerik.Sitefinity.TestArrangementService.Core;
+using Telerik.Sitefinity.TestUI.Arrangements.Framework.Server;
+using Telerik.Sitefinity.TestUtilities.CommonOperations;
+
+namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
+{
+    /// <summary>
+    /// SystemContext Arrangement
+    /// </summary>
+    public class SystemContext
+    {
+        /// <summary>
+        /// Determines whether the system context is in multisite mode.
+        /// </summary>
+        [ServerArrangement]
+        public void IsMultisiteMode()
+        {
+            var isMultisiteMode = ServerOperations.MultiSite().CheckIsMultisiteMode();
+
+            ServerArrangementContext.GetCurrent().Values.Add("isMultisiteMode", isMultisiteMode.ToString());
+        }
+
+        /// <summary>
+        /// Determines whether the system context is in multilingual mode.
+        /// </summary>
+        [ServerArrangement]
+        public void IsMultilingualMode()
+        {
+            var isMultilingualMode = ServerOperations.Multilingual().IsCurrentSiteInMultilingual;
+
+            ServerArrangementContext.GetCurrent().Values.Add("isMultilingualMode", isMultilingualMode.ToString());
+        }
+
+        /// <summary>
+        /// Gets the default arrangement culture.
+        /// </summary>
+        [ServerArrangement]
+        public void GetDefaultArrangementCulture()
+        {
+            var culture = ArrangementConfig.GetArrangementCulture();
+            ServerArrangementContext.GetCurrent().Values.Add("defaultArrangementCulture", culture);
+        }
+
+        /// <summary>
+        /// Gets the default arrangement site.
+        /// </summary>
+        [ServerArrangement]
+        public void GetDefaultArrangementSite()
+        {
+            var site = ArrangementConfig.GetArrangementSite();
+            ServerArrangementContext.GetCurrent().Values.Add("defaultArrangementSite", site);
+        }
+    }
+}

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/GridWidgets/AddAndRenameGridWidgetFromFileSystemVerifyTemplateToolbox.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/GridWidgets/AddAndRenameGridWidgetFromFileSystemVerifyTemplateToolbox.cs
@@ -18,7 +18,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
     /// <summary>
     /// AutoGenerateGridWidgetToToolboxForPageTemplate arragement.
     /// </summary>
-    public class AddAndRenameGridWidgetFromFileSystemVerifyTemplateToolbox : ITestArrangement
+    public class AddAndRenameGridWidgetFromFileSystemVerifyTemplateToolbox : TestArrangementBase
     {
         /// <summary>
         /// Server side set up. 
@@ -35,6 +35,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
             int templatesCount = pageManager.GetTemplates().Count();
             File.Copy(templateFileOriginal, templateFileCopy);
             FeatherServerOperations.ResourcePackages().WaitForTemplatesCountToIncrease(templatesCount, 1);
+            ServerOperations.Templates().SharePageTemplateWithSite(PageTemplateName, "SecondSite");
 
             string filePath = FileInjectHelper.GetDestinationFilePath(this.gridPath);
             Directory.CreateDirectory(Path.GetDirectoryName(filePath));
@@ -70,6 +71,13 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
         {
             AuthenticationHelper.AuthenticateUser(AdminEmail, AdminPass, true);
 
+            var template = ServerOperations.Templates().GetTemplateIdByTitle(PageTemplateName);
+            
+            ServerOperations.Pages().DeleteAllPages();
+            ServerOperations.Templates().UnSharePageTemplateWithSite(PageTemplateName, "SecondSite");
+            ServerOperations.Templates().DeletePageTemplate(template);
+            FeatherServerOperations.GridWidgets().RemoveGridControlFromToolboxesConfig(GridTitle);
+
             string filePath = FileInjectHelper.GetDestinationFilePath(this.gridPath);
             string templateFileCopy = FileInjectHelper.GetDestinationFilePath(this.newLayoutTemplatePath);
             string newFilePath = FileInjectHelper.GetDestinationFilePath(this.newGridPath);
@@ -77,10 +85,6 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
             File.Delete(filePath);
             File.Delete(templateFileCopy);
             File.Delete(newFilePath);
-
-            ServerOperations.Pages().DeleteAllPages();
-            ServerOperations.Templates().DeletePageTemplate(PageTemplateName);
-            FeatherServerOperations.GridWidgets().RemoveGridControlFromToolboxesConfig(GridTitle);
         }
 
         private const string AdminEmail = "admin@test.test";

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/GridWidgets/ManageGridWidgetOnThePageTemplate.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/GridWidgets/ManageGridWidgetOnThePageTemplate.cs
@@ -15,7 +15,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
     /// <summary>
     /// ManageGridWidgetOnThePageTemplate arragement.
     /// </summary>
-    public class ManageGridWidgetOnThePageTemplate : ITestArrangement
+    public class ManageGridWidgetOnThePageTemplate : TestArrangementBase
     {
         /// <summary>
         /// Server side set up. 
@@ -30,6 +30,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
             int templatesCount = pageManager.GetTemplates().Count();
             File.Copy(templateFileOriginal, templateFileCopy);
             FeatherServerOperations.ResourcePackages().WaitForTemplatesCountToIncrease(templatesCount, 1);
+            ServerOperations.Templates().SharePageTemplateWithSite(PageTemplateName, "SecondSite");
         }
 
         /// <summary>
@@ -38,10 +39,13 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
         [ServerTearDown]
         public void TearDown()
         {
+            var template = ServerOperations.Templates().GetTemplateIdByTitle(PageTemplateName);
+            
+            ServerOperations.Templates().UnSharePageTemplateWithSite(PageTemplateName, "SecondSite");
+            ServerOperations.Templates().DeletePageTemplate(template);            
+
             string templateFileCopy = FileInjectHelper.GetDestinationFilePath(this.newLayoutTemplatePath);
             File.Delete(templateFileCopy);
-
-            ServerOperations.Templates().DeletePageTemplate(PageTemplateName);
         }
 
         private const string PageTemplateName = "defaultNew";

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Module/DeactivateFeatherAndDeleteWidgetFromHybridPageTemplate.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Module/DeactivateFeatherAndDeleteWidgetFromHybridPageTemplate.cs
@@ -10,7 +10,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
     /// <summary>
     /// DeactivateFeatherAndDeleteWidgetFromHybridPageTemplate arragement.
     /// </summary>
-    public class DeactivateFeatherAndDeleteWidgetFromHybridPageTemplate : ITestArrangement
+    public class DeactivateFeatherAndDeleteWidgetFromHybridPageTemplate : TestArrangementBase
     {
         /// <summary>
         /// Server side set up. 

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Module/DeactivateFeatherAndDeleteWidgetFromPurePageTemplate.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Module/DeactivateFeatherAndDeleteWidgetFromPurePageTemplate.cs
@@ -10,7 +10,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
     /// <summary>
     /// DeactivateFeatherAndDeleteWidgetFromPurePageTemplate arragement.
     /// </summary>
-    public class DeactivateFeatherAndDeleteWidgetFromPurePageTemplate : ITestArrangement
+    public class DeactivateFeatherAndDeleteWidgetFromPurePageTemplate : TestArrangementBase
     {
         /// <summary>
         /// Server side set up. 

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Module/UninstallFeatherAndDeleteWidgetFromHybridPageTemplate.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Module/UninstallFeatherAndDeleteWidgetFromHybridPageTemplate.cs
@@ -10,7 +10,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
     /// <summary>
     /// UninstallFeatherAndDeleteWidgetFromHybridPageTemplate arragement.
     /// </summary>
-    public class UninstallFeatherAndDeleteWidgetFromHybridPageTemplate : ITestArrangement
+    public class UninstallFeatherAndDeleteWidgetFromHybridPageTemplate : TestArrangementBase
     {
         /// <summary>
         /// Server side set up. 

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Module/UninstallFeatherAndDeleteWidgetFromPurePageTemplate.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Module/UninstallFeatherAndDeleteWidgetFromPurePageTemplate.cs
@@ -10,7 +10,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
     /// <summary>
     /// UninstallFeatherAndDeleteWidgetFromPurePageTemplate arragement.
     /// </summary>
-    public class UninstallFeatherAndDeleteWidgetFromPurePageTemplate : ITestArrangement
+    public class UninstallFeatherAndDeleteWidgetFromPurePageTemplate : TestArrangementBase
     {
         /// <summary>
         /// Server side set up. 

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/MvcWidgets/MvcWidgetEditViewFromPackageCacheInvalidation.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/MvcWidgets/MvcWidgetEditViewFromPackageCacheInvalidation.cs
@@ -11,7 +11,7 @@ using Telerik.Sitefinity.TestUtilities.CommonOperations;
 
 namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
 {
-    public class MvcWidgetEditViewFromPackageCacheInvalidation : ITestArrangement
+    public class MvcWidgetEditViewFromPackageCacheInvalidation : TestArrangementBase
     {
         private const string PageName = "FeatherPage";
         private const string WidgetCaption = "TestMvcWidget";

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/MvcWidgets/MvcWidgetUseMasterDetailContentController.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/MvcWidgets/MvcWidgetUseMasterDetailContentController.cs
@@ -8,7 +8,7 @@ using Telerik.Sitefinity.TestUtilities.CommonOperations;
 
 namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
 {
-    public class MvcWidgetUseMasterDetailContentController : ITestArrangement
+    public class MvcWidgetUseMasterDetailContentController : TestArrangementBase
     {
         [ServerSetUp]
         public void SetUp()

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/MvcWidgets/MvcWidgetUseViewFromLayoutFolderAndPackage.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/MvcWidgets/MvcWidgetUseViewFromLayoutFolderAndPackage.cs
@@ -8,7 +8,7 @@ using Telerik.Sitefinity.TestUtilities.CommonOperations;
 
 namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
 {
-    public class MvcWidgetUseViewFromLayoutFolderAndPackage : ITestArrangement
+    public class MvcWidgetUseViewFromLayoutFolderAndPackage : TestArrangementBase
     {
         [ServerSetUp]
         public void SetUp()

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/ResourcePackages/AddNewLayoutFileToDefaultPackage.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/ResourcePackages/AddNewLayoutFileToDefaultPackage.cs
@@ -1,5 +1,7 @@
 ﻿using System.IO;
+using System.Linq;
 using Telerik.Sitefinity.Frontend.TestUtilities.CommonOperations;
+using Telerik.Sitefinity.Modules.Pages;
 using Telerik.Sitefinity.TestArrangementService.Attributes;
 using Telerik.Sitefinity.TestUI.Arrangements.Framework;
 using Telerik.Sitefinity.TestUtilities.CommonOperations;
@@ -9,7 +11,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
     /// <summary>
     /// AddNewLayoutFileToDefaultPackage arragement methods.
     /// </summary>
-    public class AddNewLayoutFileToDefaultPackage : ITestArrangement
+    public class AddNewLayoutFileToDefaultPackage : TestArrangementBase
     {
         [ServerArrangement]
         public void AddNewLayoutFile()
@@ -17,6 +19,10 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
             AuthenticationHelper.AuthenticateUser(AdminEmail, AdminPass, true);
             string filePath = FeatherServerOperations.ResourcePackages().GetResourcePackageDestinationFilePath(PackageName, LayoutFileName);
             FeatherServerOperations.ResourcePackages().AddNewResource(FileResource, filePath);
+            PageManager pageManager = PageManager.GetManager();
+            int templatesCount = pageManager.GetTemplates().Count();
+            FeatherServerOperations.ResourcePackages().WaitForTemplatesCountToIncrease(templatesCount, 1);
+            ServerOperations.Templates().SharePageTemplateWithSite(TemplateTitle, "SecondSite");
         }
 
         [ServerTearDown]
@@ -24,6 +30,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
         {
             AuthenticationHelper.AuthenticateUser(AdminEmail, AdminPass, true);
 
+            ServerOperations.Templates().UnSharePageTemplateWithSite(TemplateTitle, "SecondSite");
             ServerOperations.Templates().DeletePageTemplate(TemplateTitle);
 
             string filePath = FeatherServerOperations.ResourcePackages().GetResourcePackageDestinationFilePath(PackageName, LayoutFileName);           

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/ResourcePackages/EditLayoutFileFromPackageCacheInvalidation.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/ResourcePackages/EditLayoutFileFromPackageCacheInvalidation.cs
@@ -11,7 +11,7 @@ using Telerik.Sitefinity.TestUtilities.CommonOperations;
 
 namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
 {
-    public class EditLayoutFileFromPackageCacheInvalidation : ITestArrangement
+    public class EditLayoutFileFromPackageCacheInvalidation : TestArrangementBase
     {
         [ServerSetUp]
         public void AddNewLayoutFile()
@@ -25,6 +25,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
             FeatherServerOperations.ResourcePackages().AddNewResource(FileResource, filePath);
 
             FeatherServerOperations.ResourcePackages().WaitForTemplatesCountToIncrease(templatesCount, 1);
+            ServerOperations.Templates().SharePageTemplateWithSite(TemplateTitle, "SecondSite");
 
             Guid templateId = ServerOperations.Templates().GetTemplateIdByTitle(TemplateTitle);
             ServerOperations.Pages().CreatePage(PageTitle, templateId);            
@@ -43,6 +44,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.Arrangements
             AuthenticationHelper.AuthenticateUser(AdminEmail, AdminPass);
 
             ServerOperations.Pages().DeleteAllPages();
+            ServerOperations.Templates().UnSharePageTemplateWithSite(TemplateTitle, "SecondSite");
             ServerOperations.Templates().DeletePageTemplate(TemplateTitle);
 
             string filePath = FeatherServerOperations.ResourcePackages().GetResourcePackageDestinationFilePath(PackageName, LayoutFileName);

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Telerik.Sitefinity.Frontend.TestUI.Arrangements.csproj
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.Arrangements/Telerik.Sitefinity.Frontend.TestUI.Arrangements.csproj
@@ -201,6 +201,8 @@
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="ApplicationPreStart.cs" />
+    <Compile Include="Framework\TestArrangementBase.cs" />
+    <Compile Include="Framework\Utilities\Utilities.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Designers\DesignerAllComponentsNoJsonNoJs.cs" />
     <Compile Include="Designers\DesignerAllComponentsNoJsonWithJs.cs" />

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/FeatherTestCase.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/FeatherTestCase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using ArtOfTest.WebAii.Core;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Telerik.Sitefinity.Frontend.TestUI.Framework;
 using Telerik.Sitefinity.MS.TestUI.Framework.MSTest;
 using Telerik.TestUI.Core.Configuration;
 
@@ -58,5 +59,66 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases
         {
             base.ServerCleanup();
         }
+
+        /// <summary>
+        /// Gets a value indicating whether the site is in multisite.
+        /// </summary>
+        /// <value>True if in multisite, false if in single site.</value>
+        protected bool IsMultisite
+        {
+            get
+            {
+                if (this.isMultisite == null)
+                {
+                    this.isMultisite = BAT.Utilities().CheckIsMultisiteMode();
+                }
+
+                return (bool)this.isMultisite;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether the current site is in multilingual.
+        /// </summary>
+        /// <value>True if in multilingual, false if in monolingual.</value>
+        protected bool IsMultilingual
+        {
+            get
+            {
+                if (this.isMultilingual == null)
+                {
+                    this.isMultilingual = BAT.Utilities().IsCurrentSiteInMultilingual();
+                }
+
+                return (bool)this.isMultilingual;
+            }
+        }
+
+        /// <summary>
+        /// Gets the culture.
+        /// </summary>
+        /// <value>The culture.</value>
+        protected virtual string Culture
+        {
+            get
+            {
+                if (this.culture == "undefined")
+                {
+                    if (this.IsMultilingual)
+                        this.culture = BAT.Utilities().GetDefaultArrangementCulture();
+                    else
+                        this.culture = null;
+                }
+
+                return this.culture;
+            }
+        }
+
+        private bool? isMultisite = null;
+        private bool? isMultilingual = null;
+        private string culture = "undefined";
+        protected const string AdminEmail = "admin@test.test";
+        protected const string AdminPassword = "admin@2";
+        protected const string AdminNickname = "admin admin";
     }
 }

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/GridWidgets/AutoGenerateGridWidgetToToolboxForPageTemplate.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/GridWidgets/AutoGenerateGridWidgetToToolboxForPageTemplate.cs
@@ -26,12 +26,12 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.GridWidgets
             RuntimeSettingsModificator.ExecuteWithClientTimeout(800000, () => BAT.Macros().User().EnsureAdminLoggedIn());
             RuntimeSettingsModificator.ExecuteWithClientTimeout(800000, () => BAT.Macros().NavigateTo().CustomPage("~/sitefinity/design/pagetemplates", true, null, new HtmlFindExpression("class=~sfMain")));
             BAT.Wrappers().Backend().PageTemplates().PageTemplateMainScreen().OpenTemplateEditor(PageTemplateName);
-            BAT.Wrappers().Backend().Pages().PageZoneEditorWrapper().SwitchEditorLayoutMode(EditorLayoutMode.Layout);            
+            BAT.Wrappers().Backend().Pages().PageZoneEditorWrapper().SwitchEditorLayoutMode(EditorLayoutMode.Layout);
             BATFrontend.Wrappers().Backend().Pages().PageZoneEditorWrapper().DragAndDropLayoutWidgetToPlaceholder(LayoutCaption);
             BAT.Wrappers().Backend().Pages().PageLayoutEditorWrapper().VerifyLayoutWidgetPageEditor(LayoutCaption);
             BAT.Wrappers().Backend().PageTemplates().PageTemplateModifyScreen().PublishTemplate();
 
-            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false);
+            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false, this.Culture);
             BATFrontend.Wrappers().Frontend().Widgets().GridWidgets().VerifyNewGridWidgetOnTheFrontend(this.layouts);
 
             BAT.Arrange(this.TestName).ExecuteArrangement("RenameGridWidgetFromFileSystem");
@@ -39,7 +39,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.GridWidgets
             BAT.Macros().NavigateTo().Design().PageTemplates();
             BAT.Wrappers().Backend().PageTemplates().PageTemplateMainScreen().OpenTemplateEditor(PageTemplateName);
             BAT.Wrappers().Backend().Pages().PageZoneEditorWrapper().SwitchEditorLayoutMode(EditorLayoutMode.Layout);
-            
+
             Assert.IsFalse(
                 BATFrontend.Wrappers().Backend().Pages().PageZoneEditorWrapper().IsLayoutWidgetPresentInToolbox(LayoutCaption),
                 "Layout widget is found in the toolbox");
@@ -52,7 +52,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.GridWidgets
             BAT.Wrappers().Backend().Pages().PageLayoutEditorWrapper().VerifyLayoutWidgetPageEditor(LayoutRenamed);
 
             BAT.Wrappers().Backend().PageTemplates().PageTemplateModifyScreen().PublishTemplate();
-            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false);
+            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false, this.Culture);
 
             HttpResponseMessage response = new HttpResponseMessage();
             Assert.AreEqual(200, (int)response.StatusCode);
@@ -63,7 +63,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.GridWidgets
         /// Performs Server Setup and prepare the system with needed data.
         /// </summary>
         protected override void ServerSetup()
-        {           
+        {
             BAT.Arrange(this.TestName).ExecuteSetUp();
         }
 

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/Module/DeactivateFeatherAndDeleteWidgetFromHybridPageTemplate.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/Module/DeactivateFeatherAndDeleteWidgetFromHybridPageTemplate.cs
@@ -29,13 +29,14 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 // Add widget to template
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().User().EnsureAdminLoggedIn());
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageTemplatesPageUrl, false, null, new HtmlFindExpression("InnerText=" + PageTemplateName)));
+                BAT.Wrappers().Backend().MLOperations().MLGridOperations().ChangeLanguageFromDropdownMenuML(1);
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateMainScreen().OpenTemplateEditor(PageTemplateName);
                 BATFrontend.Wrappers().Backend().Pages().PageZoneEditorWrapper().DragAndDropWidgetToPlaceholder(WidgetName, Placeholder);
                 Assert.IsTrue(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateModifyScreen().PublishTemplate();
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsTrue(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
 
                 // Deactivate Feather
@@ -43,26 +44,27 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 featherDeactivated = true;
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsFalse(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
 
                 // Remove widget from template
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().User().EnsureAdminLoggedIn());
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageTemplatesPageUrl, false, null, new HtmlFindExpression("InnerText=" + PageTemplateName)));
+                BAT.Wrappers().Backend().MLOperations().MLGridOperations().ChangeLanguageFromDropdownMenuML(1);
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateMainScreen().OpenTemplateEditor(PageTemplateName);
                 BAT.Wrappers().Backend().Pages().PageZoneEditorWrapper().DeleteWidget(WidgetName);
                 Assert.IsFalse(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateModifyScreen().PublishTemplate();
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsFalse(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
 
                 // Activate Feather
                 BATFrontend.Wrappers().Backend().FrontendModule().FrontendModule().ActivateFeather(ActiveBrowser);
                 featherDeactivated = false;
             }
-            finally 
+            finally
             {
                 if (featherDeactivated)
                 {
@@ -71,7 +73,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 }
             }
         }
-        
+
         /// <summary>
         /// Performs Server Setup and prepare the system with needed data.
         /// </summary>

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/Module/DeactivateFeatherAndDeleteWidgetFromPurePageTemplate.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/Module/DeactivateFeatherAndDeleteWidgetFromPurePageTemplate.cs
@@ -29,13 +29,14 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 // Add widget to template
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().User().EnsureAdminLoggedIn());
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageTemplatesPageUrl, false, null, new HtmlFindExpression("InnerText=" + PageTemplateName)));
+                BAT.Wrappers().Backend().MLOperations().MLGridOperations().ChangeLanguageFromDropdownMenuML(1);
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateMainScreen().OpenTemplateEditor(PageTemplateName);
                 BATFrontend.Wrappers().Backend().Pages().PageZoneEditorWrapper().DragAndDropWidgetToPlaceholder(WidgetName, Placeholder);
                 Assert.IsTrue(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateModifyScreen().PublishTemplate();
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, null, new HtmlFindExpression("InnerText=~" + WidgetContent)));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture, new HtmlFindExpression("InnerText=~" + WidgetContent)));
                 Assert.IsTrue(BATFrontend.Wrappers().Backend().Widgets().WidgetsWrapper().IsElementByInnerTextPresent(WidgetContent));
 
                 // Deactivate Feather
@@ -43,26 +44,27 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 featherDeactivated = true;
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsFalse(BATFrontend.Wrappers().Backend().Widgets().WidgetsWrapper().IsElementByInnerTextPresent(WidgetContent));
 
                 // Remove widget from template
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().User().EnsureAdminLoggedIn());
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageTemplatesPageUrl, false, null, new HtmlFindExpression("InnerText=" + PageTemplateName)));
+                BAT.Wrappers().Backend().MLOperations().MLGridOperations().ChangeLanguageFromDropdownMenuML(1);
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateMainScreen().OpenTemplateEditor(PageTemplateName);
                 BAT.Wrappers().Backend().Pages().PageZoneEditorWrapper().DeleteWidget(WidgetName);
                 Assert.IsFalse(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateModifyScreen().PublishTemplate();
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsFalse(BATFrontend.Wrappers().Backend().Widgets().WidgetsWrapper().IsElementByInnerTextPresent(WidgetContent));
 
                 // Activate Feather
                 BATFrontend.Wrappers().Backend().FrontendModule().FrontendModule().ActivateFeather(ActiveBrowser);
                 featherDeactivated = false;
             }
-            finally 
+            finally
             {
                 if (featherDeactivated)
                 {
@@ -71,7 +73,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 }
             }
         }
-        
+
         /// <summary>
         /// Performs Server Setup and prepare the system with needed data.
         /// </summary>

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/Module/UninstallFeatherAndDeleteWidgetFromHybridPageTemplate.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/Module/UninstallFeatherAndDeleteWidgetFromHybridPageTemplate.cs
@@ -29,13 +29,14 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 // Add widget to template
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().User().EnsureAdminLoggedIn());
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageTemplatesPageUrl, false, null, new HtmlFindExpression("InnerText=" + PageTemplateName)));
+                BAT.Wrappers().Backend().MLOperations().MLGridOperations().ChangeLanguageFromDropdownMenuML(1);
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateMainScreen().OpenTemplateEditor(PageTemplateName);
                 BATFrontend.Wrappers().Backend().Pages().PageZoneEditorWrapper().DragAndDropWidgetToPlaceholder(WidgetName, Placeholder);
                 Assert.IsTrue(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateModifyScreen().PublishTemplate();
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsTrue(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
 
                 // Uninstall Feather
@@ -43,26 +44,27 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 featherUninstalled = true;
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsFalse(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
 
                 // Remove widget from template
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().User().EnsureAdminLoggedIn());
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageTemplatesPageUrl, false, null, new HtmlFindExpression("InnerText=" + PageTemplateName)));
+                BAT.Wrappers().Backend().MLOperations().MLGridOperations().ChangeLanguageFromDropdownMenuML(1);
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateMainScreen().OpenTemplateEditor(PageTemplateName);
                 BAT.Wrappers().Backend().Pages().PageZoneEditorWrapper().DeleteWidget(WidgetName);
                 Assert.IsFalse(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateModifyScreen().PublishTemplate();
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsFalse(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
 
                 // Install Feather
                 BATFrontend.Wrappers().Backend().FrontendModule().FrontendModule().InstallFeather(ActiveBrowser);
                 featherUninstalled = false;
             }
-            finally 
+            finally
             {
                 if (featherUninstalled)
                 {
@@ -71,7 +73,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 }
             }
         }
-        
+
         /// <summary>
         /// Performs Server Setup and prepare the system with needed data.
         /// </summary>

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/Module/UninstallFeatherAndDeleteWidgetFromPurePageTemplate.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/Module/UninstallFeatherAndDeleteWidgetFromPurePageTemplate.cs
@@ -29,13 +29,14 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 // Add widget to template
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().User().EnsureAdminLoggedIn());
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageTemplatesPageUrl, false, null, new HtmlFindExpression("InnerText=" + PageTemplateName)));
+                BAT.Wrappers().Backend().MLOperations().MLGridOperations().ChangeLanguageFromDropdownMenuML(1);
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateMainScreen().OpenTemplateEditor(PageTemplateName);
                 BATFrontend.Wrappers().Backend().Pages().PageZoneEditorWrapper().DragAndDropWidgetToPlaceholder(WidgetName, Placeholder);
                 Assert.IsTrue(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateModifyScreen().PublishTemplate();
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsTrue(BATFrontend.Wrappers().Backend().Widgets().WidgetsWrapper().IsElementByInnerTextPresent(WidgetContent));
 
                 // Uninstall Feather
@@ -43,26 +44,27 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 featherUninstalled = true;
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsFalse(BATFrontend.Wrappers().Backend().Widgets().WidgetsWrapper().IsElementByInnerTextPresent(WidgetContent));
 
                 // Remove widget from template
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().User().EnsureAdminLoggedIn());
                 RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageTemplatesPageUrl, false, null, new HtmlFindExpression("InnerText=" + PageTemplateName)));
+                BAT.Wrappers().Backend().MLOperations().MLGridOperations().ChangeLanguageFromDropdownMenuML(1);
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateMainScreen().OpenTemplateEditor(PageTemplateName);
                 BAT.Wrappers().Backend().Pages().PageZoneEditorWrapper().DeleteWidget(WidgetName);
                 Assert.IsFalse(BAT.Wrappers().Frontend().Pages().PagesWrapperFrontend().IsHtmlControlPresent(WidgetContent));
                 BAT.Wrappers().Backend().PageTemplates().PageTemplateModifyScreen().PublishTemplate();
 
                 // Verify on frontend
-                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false));
+                RuntimeSettingsModificator.ExecuteWithClientTimeout(ClientTimeoutInterval, () => BAT.Macros().NavigateTo().CustomPage(PageUrl, false, this.Culture));
                 Assert.IsFalse(BATFrontend.Wrappers().Backend().Widgets().WidgetsWrapper().IsElementByInnerTextPresent(WidgetContent));
 
                 // Install Feather
                 BATFrontend.Wrappers().Backend().FrontendModule().FrontendModule().InstallFeather(ActiveBrowser);
                 featherUninstalled = false;
             }
-            finally 
+            finally
             {
                 if (featherUninstalled)
                 {
@@ -71,7 +73,7 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.Module
                 }
             }
         }
-        
+
         /// <summary>
         /// Performs Server Setup and prepare the system with needed data.
         /// </summary>

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/MvcWidgets/MvcWidgetApplyNewView.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/MvcWidgets/MvcWidgetApplyNewView.cs
@@ -23,13 +23,13 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.MvcWidgets
         TestCategory(FeatherTestCategories.PagesAndContent)]
         public void MvcWidgetUseViewFromLayoutFolderAndPackage()
         {
-            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false);
+            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false, this.Culture);
             Assert.IsTrue(ActiveBrowser.ContainsText(DefaultViewText), "Default view text is not correct.");
             BAT.Arrange(this.TestName).ExecuteArrangement("AddNewViewToLayoutsFolder");
-            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false);
+            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false, this.Culture);
             Assert.IsTrue(ActiveBrowser.ContainsText(DefaultViewFromLayoutsFolderText), "Default view text from Layouts folder is not correct.");
             BAT.Arrange(this.TestName).ExecuteArrangement("AddNewViewToPackage");
-            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false);
+            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false, this.Culture);
             Assert.IsTrue(ActiveBrowser.ContainsText(DefaultViewFromPackageText), "Default view text from package is not correct.");
         }
 

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/MvcWidgets/MvcWidgetEditViewCacheInvalidation.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/MvcWidgets/MvcWidgetEditViewCacheInvalidation.cs
@@ -23,10 +23,10 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.MvcWidgets
         TestCategory(FeatherTestCategories.PagesAndContent)]
         public void MvcWidgetEditViewFromPackageCacheInvalidation()
         {
-            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false);
+            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false, this.Culture);
             Assert.IsTrue(ActiveBrowser.ContainsText(DefaultViewFromPackageText), "Default view text is not correct.");
             BAT.Arrange(this.TestName).ExecuteArrangement("EditViewFromPackage");
-            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false);
+            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false, this.Culture);
             Assert.IsTrue(ActiveBrowser.ContainsText(DefaultViewFromPackageEditedText), "Default view text after edit is not correct.");
         }
 

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/MvcWidgets/MvcWidgetUseMasterDetailContentController.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/MvcWidgets/MvcWidgetUseMasterDetailContentController.cs
@@ -23,8 +23,8 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.MvcWidgets
         TestCategory(FeatherTestCategories.PagesAndContent)]
         public void MvcWidgetUseMasterDetailContentController()
         {
-            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false);
-            Assert.IsTrue(ActiveBrowser.ContainsText(PageText), "Page text is not correct.");           
+            BAT.Macros().NavigateTo().CustomPage("~/" + PageName.ToLower(), false, this.Culture);
+            Assert.IsTrue(ActiveBrowser.ContainsText(PageText), "Page text is not correct.");
         }
 
         /// <summary>

--- a/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/ResourcePackages/EditLayoutFileCacheInvalidation.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUI.TestCases/ResourcePackages/EditLayoutFileCacheInvalidation.cs
@@ -22,12 +22,12 @@ namespace Telerik.Sitefinity.Frontend.TestUI.TestCases.ResourcePackages
         TestCategory(FeatherTestCategories.PagesAndContent)]
         public void EditLayoutFileFromPackageCacheInvalidation()
         {
-            BAT.Macros().NavigateTo().CustomPage("~/" + PageTitle.ToLower(), false);
+            BAT.Macros().NavigateTo().CustomPage("~/" + PageTitle.ToLower(), false, this.Culture);
             Assert.IsTrue(ActiveBrowser.ContainsText(LayoutFileText), "Layout text is not correct.");
 
             BAT.Arrange(this.TestName).ExecuteArrangement("EditLayoutFile");
 
-            BAT.Macros().NavigateTo().CustomPage("~/" + PageTitle.ToLower(), false);
+            BAT.Macros().NavigateTo().CustomPage("~/" + PageTitle.ToLower(), false, this.Culture);
             Assert.IsTrue(ActiveBrowser.ContainsText(LayoutFileNewText), "Layout text after edit is not correct.");
         }
 

--- a/Tests/Telerik.Sitefinity.Frontend.TestUtilities/CommonOperations/Pages/GridWidgetsOperations.cs
+++ b/Tests/Telerik.Sitefinity.Frontend.TestUtilities/CommonOperations/Pages/GridWidgetsOperations.cs
@@ -5,6 +5,7 @@ using System.Text;
 using Telerik.Sitefinity.Configuration;
 using Telerik.Sitefinity.Frontend.GridSystem;
 using Telerik.Sitefinity.Modules.Pages.Configuration;
+using Telerik.Sitefinity.Restriction;
 
 namespace Telerik.Sitefinity.Frontend.TestUtilities.CommonOperations.Pages
 {
@@ -22,7 +23,10 @@ namespace Telerik.Sitefinity.Frontend.TestUtilities.CommonOperations.Pages
             var itemToDelete = section.Tools.FirstOrDefault<ToolboxItem>(e => e.Name == gridName);
             section.Tools.Remove(itemToDelete);
 
-            configurationManager.SaveSection(toolboxesConfig);
+            using (new UnrestrictedModeRegion())
+            {
+                configurationManager.SaveSection(toolboxesConfig, true);
+            }
         }
     }
 }


### PR DESCRIPTION
EditLayoutFileFromPackageCacheInvalidation
AddNewLayoutFileToDefaultPackage
MvcWidgetUseMasterDetailContentController
MvcWidgetEditViewFromPackageCacheInvalidation
MvcWidgetApplyNewView.MvcWidgetUseViewFromLayoutFolderAndPackage
UninstallFeatherAndDeleteWidgetFromPurePageTemplate
UninstallFeatherAndDeleteWidgetFromHybridPageTemplate
DeactivateFeatherAndDeleteWidgetFromPurePageTemplate
DeactivateFeatherAndDeleteWidgetFromHybridPageTemplate
ManageGridWidgetOnThePageTemplate
AddAndRenameGridWidgetFromFileSystemVerifyTemplateToolbox