### PR TITLE
Fix formatting of GetPrice()

### DIFF
--- a/Telerik.Sitefinity.Frontend/Mvc/Models/ItemViewModel.cs
+++ b/Telerik.Sitefinity.Frontend/Mvc/Models/ItemViewModel.cs
@@ -229,7 +229,7 @@ namespace Telerik.Sitefinity.Frontend.Mvc.Models
             if (fieldValue == null)
                 return null;
 
-            var formattedValue = string.Format(fieldValue.ToString(), format);
+            var formattedValue = fieldValue.ToString(format);
 
             return formattedValue;
         }


### PR DESCRIPTION
I noticed an issue when trying to use `GetPrice()` method on `ItemViewModel`.  It was trying to format a value after calling `.ToString()` which does not work.