### PR TITLE
MvcTemplateEditorRouteHandler changed to public

### DIFF
--- a/Telerik.Sitefinity.Frontend/Mvc/Infrastructure/Routing/MvcTemplateEditorRouteHandler.cs
+++ b/Telerik.Sitefinity.Frontend/Mvc/Infrastructure/Routing/MvcTemplateEditorRouteHandler.cs
@@ -10,7 +10,7 @@ namespace Telerik.Sitefinity.Frontend.Mvc.Infrastructure.Routing
     /// <summary>
     /// Extended version of the TemplateEditorRouteHandler that injects logic handling MVC layout files.
     /// </summary>
-    internal class MvcTemplateEditorRouteHandler : TemplateEditorRouteHandler
+    public class MvcTemplateEditorRouteHandler : TemplateEditorRouteHandler
     {
         /// <summary>
         /// Builds the handler.


### PR DESCRIPTION
Change MvcTemplateEditorRouteHandler to public to allow developers to override and utilize this route when developing their Sitefinity sites.

Sitefinity feedback portal issue: https://feedback.telerik.com/Project/153/Feedback/Details/232191-mvctemplateeditorroutehandler-marked-as-internal