### PR TITLE
Added parent filter for dynamic selector.

### DIFF
--- a/Telerik.Sitefinity.Frontend/client-components/selectors/common/sf-services.js
+++ b/Telerik.Sitefinity.Frontend/client-components/selectors/common/sf-services.js
@@ -67,6 +67,14 @@
                 this.filter += this.liveItemsFilter;
                 return this;
             },
+            parentIdFilter: function (parentId) {
+                if (parentId)
+                    this.filter += 'SystemParentId==' + parentId;
+                else
+                    return this.trimOperator();
+
+                return this;
+            },
             cultureFilter: function () {
                 var culture = serverContext.getUICulture();
                 if (culture) {

--- a/Telerik.Sitefinity.Frontend/client-components/selectors/dynamic-modules/sf-data-service.js
+++ b/Telerik.Sitefinity.Frontend/client-components/selectors/dynamic-modules/sf-data-service.js
@@ -14,6 +14,28 @@
                 return serviceHelper.getResource(url);
             };
 
+            var getLiveItemsByParent = function (itemType, provider, skip, take, search, searchField, parentId) {
+                var filter = serviceHelper.filterBuilder()
+                    .parentIdFilter(parentId)
+                    .and()
+                    .searchFilter(search, null, searchField)
+                    .and()
+                    .cultureFilter()
+                    .getFilter();
+                dataItemPromise = getResource('live').get(
+                    {
+                        itemType: itemType,
+                        itemSurrogateType: itemType,
+                        provider: provider,
+                        skip: skip,
+                        take: take,
+                        filter: filter
+                    })
+                    .$promise;
+
+                return dataItemPromise;
+            };
+
             var getLiveItems = function (itemType, provider, skip, take, search, searchField) {
                 var filter = serviceHelper.filterBuilder()
                     .searchFilter(search, null, searchField)
@@ -111,6 +133,7 @@
 
             return {
                 /* Returns the data items. */
+                getLiveItemsByParent: getLiveItemsByParent,
                 getLiveItems: getLiveItems,
                 getSpecificLiveItems: getSpecificLiveItems,
                 getItems: getItems,

--- a/Telerik.Sitefinity.Frontend/client-components/selectors/dynamic-modules/sf-dynamic-items-selector.js
+++ b/Telerik.Sitefinity.Frontend/client-components/selectors/dynamic-modules/sf-dynamic-items-selector.js
@@ -7,11 +7,14 @@
                 link: {
                     pre: function (scope, element, attrs, ctrl) {
                         var master = attrs.sfMaster === 'true' || attrs.sfMaster === 'True';
-
+                        var parentId = attrs.sfParentId;
+                        
                         ctrl.getItems = function (skip, take, search) {
                             var provider = ctrl.$scope.sfProvider;
                             if (master)
                                 return dataService.getItems(ctrl.$scope.sfItemType, provider, skip, take, search, ctrl.identifierField);
+                            else if (parentId)
+                                return dataService.getLiveItemsByParent(ctrl.$scope.sfItemType, provider, skip, take, search, ctrl.identifierField, parentId);
                             else
                                 return dataService.getLiveItems(ctrl.$scope.sfItemType, provider, skip, take, search, ctrl.identifierField);
                         };


### PR DESCRIPTION
Added sf-parent-id attribute to the sf-dynamic-items-selector to allow for specification of parent id. Added required functions to support change to sf-data-service and sf-service.