### PR TITLE
Solve Bug in Sitefinity having multiple sf-media-field in same designer view (document/videos) always change/update first sf-media-field control. Also bug present when having sf-auto-open-selector attribute present in sf-media-field always open first sf-media-field

### DIFF
--- a/Telerik.Sitefinity.Frontend/client-components/fields/media-field/sf-media-field.js
+++ b/Telerik.Sitefinity.Frontend/client-components/fields/media-field/sf-media-field.js
@@ -117,7 +117,9 @@
                     scope.mediaItemDeleted = false;
 
                     var autoOpenSelector = attrs.sfAutoOpenSelector !== undefined && attrs.sfAutoOpenSelector.toLowerCase() !== 'false';
-
+                    
+                    var mediaElement = element;
+                    
                     var mediaType = sfMediaTypeResolver.get(scope.sfMediaType);
 
                     var getDateFromString = function (dateStr) {
@@ -277,7 +279,18 @@
                             scope.model.filterObject.status = attrs.sfMaster === 'true' || attrs.sfMaster === 'True' ? 'master' : 'live';
                         }
 
-                        var mediaSelectorModalScope = angular.element('.mediaSelectorModal').scope();
+                        var mediaSelector = angular.element('.mediaSelectorModal');
+
+                        //Add below lines of code to solve multiple sf-media-field selector in same designer view
+                        if (mediaElement && mediaElement.length > 0) {
+                            var el = mediaElement[0].querySelector('.mediaSelectorModal');
+                            if (el) {
+                                var ngEl = angular.element(el);
+                                if (ngEl) {
+                                    mediaSelector = ngEl;
+                                }
+                            }
+                        }
 
                         if (mediaSelectorModalScope)
                             mediaSelectorModalScope.$openModalDialog();


### PR DESCRIPTION
Bug in Sitefinity having multiple sf-media-field in same designer view (document/videos) always update first sf-media-field element. Also bug present when having sf-auto-open-selector attribute presents always open first sf-media-field.

code lines added
                        //Add below lines of code to solve multiple sf-media-field selector in same designer view
                        if (mediaElement && mediaElement.length > 0) {
                            var el = mediaElement[0].querySelector('.mediaSelectorModal');
                            if (el) {
                                var ngEl = angular.element(el);
                                if (ngEl) {
                                    mediaSelector = ngEl;
                                }
                            }
                        }